### PR TITLE
Added custom styling to bootstrap

### DIFF
--- a/client/src/scss/_custom-mixins.scss
+++ b/client/src/scss/_custom-mixins.scss
@@ -1,0 +1,85 @@
+// Media of at most the maximum breakpoint width. No query for the largest breakpoint.
+// Makes the @content apply to the given breakpoint and narrower.
+@mixin container-breakpoint-down($name, $breakpoints: $container-breakpoints) {
+  $max: breakpoint-max($name, $breakpoints);
+  @if $max {
+    @container (max-width: $max) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
+
+// Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
+// Makes the @content apply to the given breakpoint and wider.
+@mixin container-breakpoint-up($name, $breakpoints: $container-breakpoints) {
+  $min: breakpoint-min($name, $breakpoints);
+  @if $min {
+    @container (min-width: #{$min}) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
+@mixin make-container-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $container-breakpoints) {
+  @each $breakpoint in map-keys($breakpoints) {
+    $infix: breakpoint-infix($breakpoint, $breakpoints);
+
+    @include container-breakpoint-up($breakpoint, $breakpoints) {
+      // Provide basic `.col-{bp}` classes for equal-width flexbox columns
+      .con-col#{$infix} {
+        flex: 1 0 0%; // Flexbugs #4: https://github.com/philipwalton/flexbugs#flexbug-4
+      }
+
+      .row-con-cols#{$infix}-auto > * {
+        @include make-col-auto();
+      }
+
+      @if $grid-row-columns > 0 {
+        @for $i from 1 through $grid-row-columns {
+          .row-con-cols#{$infix}-#{$i} {
+            @include row-cols($i);
+          }
+        }
+      }
+
+      .con-col#{$infix}-auto {
+        @include make-col-auto();
+      }
+
+      @if $columns > 0 {
+        @for $i from 1 through $columns {
+          .con-col#{$infix}-#{$i} {
+            @include make-col($i, $columns);
+          }
+        }
+
+        // `$columns - 1` because offsetting by the width of an entire row isn't possible
+        @for $i from 0 through ($columns - 1) {
+          @if not ($infix == "" and $i == 0) { // Avoid emitting useless .offset-0
+            .con-offset#{$infix}-#{$i} {
+              @include make-col-offset($i, $columns);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@for $i from 2 through 5 { 
+  .TT-template-column-wrap-#{$i} { 
+    columns: $i; 
+  } 
+  .TT-template-column-wrap-#{$i} > div {
+    break-inside: avoid; 
+  }
+}
+
+.con-levelset {
+  container-type: inline-size;
+};

--- a/client/src/scss/_custom_variables.scss
+++ b/client/src/scss/_custom_variables.scss
@@ -1,0 +1,143 @@
+@use "sass:map";
+
+$TT-primary-100: tint-color($TT-primary, 80%) !default;
+$TT-primary-200: tint-color($TT-primary, 60%) !default;
+$TT-primary-300: tint-color($TT-primary, 40%) !default;
+$TT-primary-400: tint-color($TT-primary, 20%) !default;
+$TT-primary-500: $TT-primary !default;
+$TT-primary-600: shade-color($TT-primary, 20%) !default;
+$TT-primary-700: shade-color($TT-primary, 40%) !default;
+$TT-primary-800: shade-color($TT-primary, 60%) !default;
+$TT-primary-900: shade-color($TT-primary, 80%) !default;
+
+$TT-secondary-100: tint-color($TT-secondary, 80%) !default;
+$TT-secondary-200: tint-color($TT-secondary, 60%) !default;
+$TT-secondary-300: tint-color($TT-secondary, 40%) !default;
+$TT-secondary-400: tint-color($TT-secondary, 20%) !default;
+$TT-secondary-500: $TT-secondary !default;
+$TT-secondary-600: shade-color($TT-secondary, 20%) !default;
+$TT-secondary-700: shade-color($TT-secondary, 40%) !default;
+$TT-secondary-800: shade-color($TT-secondary, 60%) !default;
+$TT-secondary-900: shade-color($TT-secondary, 80%) !default;
+
+$TT-tertiary-100: tint-color($TT-tertiary, 80%) !default;
+$TT-tertiary-200: tint-color($TT-tertiary, 60%) !default;
+$TT-tertiary-300: tint-color($TT-tertiary, 40%) !default;
+$TT-tertiary-400: tint-color($TT-tertiary, 20%) !default;
+$TT-tertiary-500: $TT-tertiary !default;
+$TT-tertiary-600: shade-color($TT-tertiary, 20%) !default;
+$TT-tertiary-700: shade-color($TT-tertiary, 40%) !default;
+$TT-tertiary-800: shade-color($TT-tertiary, 60%) !default;
+$TT-tertiary-900: shade-color($TT-tertiary, 80%) !default;
+
+$TT-quaternary-100: tint-color($TT-quaternary, 80%) !default;
+$TT-quaternary-200: tint-color($TT-quaternary, 60%) !default;
+$TT-quaternary-300: tint-color($TT-quaternary, 40%) !default;
+$TT-quaternary-400: tint-color($TT-quaternary, 20%) !default;
+$TT-quaternary-500: $TT-quaternary !default;
+$TT-quaternary-600: shade-color($TT-quaternary, 20%) !default;
+$TT-quaternary-700: shade-color($TT-quaternary, 40%) !default;
+$TT-quaternary-800: shade-color($TT-quaternary, 60%) !default;
+$TT-quaternary-900: shade-color($TT-quaternary, 80%) !default;
+
+$colors: map-remove($colors, "indigo", "purple", "pink", "orange", "teal");
+
+$colors: map-merge(
+  (
+    "TT-primary": $TT-primary,
+    "TT-secondary": $TT-secondary,
+    "TT-tertiary": $TT-tertiary,
+    "TT-quaternary": $TT-quaternary,
+  ),
+  $colors
+);
+
+$TT-primarys: (
+  "TT-primary": $TT-primary,
+  "TT-primary-100": $TT-primary-100,
+  "TT-primary-200": $TT-primary-200,
+  "TT-primary-300": $TT-primary-300,
+  "TT-primary-400": $TT-primary-400,
+  "TT-primary-500": $TT-primary-500,
+  "TT-primary-600": $TT-primary-600,
+  "TT-primary-700": $TT-primary-700,
+  "TT-primary-800": $TT-primary-800,
+  "TT-primary-900": $TT-primary-900,
+) !default;
+
+$TT-secondarys: (
+  "TT-secondary": $TT-secondary,
+  "TT-secondary-100": $TT-secondary-100,
+  "TT-secondary-200": $TT-secondary-200,
+  "TT-secondary-300": $TT-secondary-300,
+  "TT-secondary-400": $TT-secondary-400,
+  "TT-secondary-500": $TT-secondary-500,
+  "TT-secondary-600": $TT-secondary-600,
+  "TT-secondary-700": $TT-secondary-700,
+  "TT-secondary-800": $TT-secondary-800,
+  "TT-secondary-900": $TT-secondary-900
+) !default;
+
+$TT-tertiarys: (
+  "TT-tertiary": $TT-tertiary,
+  "TT-tertiary-100": $TT-tertiary-100,
+  "TT-tertiary-200": $TT-tertiary-200,
+  "TT-tertiary-300": $TT-tertiary-300,
+  "TT-tertiary-400": $TT-tertiary-400,
+  "TT-tertiary-500": $TT-tertiary-500,
+  "TT-tertiary-600": $TT-tertiary-600,
+  "TT-tertiary-700": $TT-tertiary-700,
+  "TT-tertiary-800": $TT-tertiary-800,
+  "TT-tertiary-900": $TT-tertiary-900
+) !default;
+
+$TT-quaternarys: (
+  "TT-quaternary": $TT-quaternary,
+  "TT-quaternary-100": $TT-quaternary-100,
+  "TT-quaternary-200": $TT-quaternary-200,
+  "TT-quaternary-300": $TT-quaternary-300,
+  "TT-quaternary-400": $TT-quaternary-400,
+  "TT-quaternary-500": $TT-quaternary-500,
+  "TT-quaternary-600": $TT-quaternary-600,
+  "TT-quaternary-700": $TT-quaternary-700,
+  "TT-quaternary-800": $TT-quaternary-800,
+  "TT-quaternary-900": $TT-quaternary-900
+) !default;
+
+
+$TTColors: map-merge(
+  $TT-primarys,
+  map-merge(
+    $TT-secondarys,
+    map-merge($TT-tertiarys, $TT-quaternarys)
+  )
+);
+
+$ThemeTransitionTime: 0.2s ease-in-out all;
+$HoverTransitionTime: 0.3s ease-in-out all;
+$RenderMenuWidth: 300px;
+
+$BannerMargin: 230px;
+
+
+$container-breakpoints: (
+  xxs: 120px,
+  xs: 340px,
+  sm: 540px,
+  md: 720px,
+  lg: 960px,
+  xl: 1140px,
+  xxl: 1320px
+);
+
+$custome-font-size: (
+    '7': '2rem',
+    '8': '1.5rem',
+    '9': '1rem',
+    '10': '0.5rem'
+);
+
+$display-font-sizes: map-merge($display-font-sizes, $custome-font-size);
+
+$carousel-control-color: $TT-primary !default;
+$carousel-indicator-active-bg: $TT-primary !default;

--- a/client/src/scss/_initial-variables.scss
+++ b/client/src/scss/_initial-variables.scss
@@ -1,0 +1,9 @@
+$TT-primary: #263752 !default;
+$TT-secondary: #AFCFCE !default;
+$TT-tertiary: #F8F8F8 !default;
+$TT-quaternary: #F4F2EA !default;
+$primary: $TT-primary;
+$secondary: $TT-secondary;
+$success: $TT-tertiary;
+$tertiary: $TT-tertiary;
+$enable-negative-margins: true;

--- a/client/src/scss/main.scss
+++ b/client/src/scss/main.scss
@@ -1,3 +1,16 @@
+@import "./initial-variables";
+
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+  xxl: 1500px
+);
+
+$enable-cssgrid: true;
+
 @import "../../node_modules/bootstrap/scss/mixins/banner";
 @include bsBanner("");
 
@@ -7,9 +20,14 @@
 @import "../../node_modules/bootstrap/scss/functions";
 @import "../../node_modules/bootstrap/scss/variables";
 @import "../../node_modules/bootstrap/scss/variables-dark";
+
+@import "./custom_variables";
+
 @import "../../node_modules/bootstrap/scss/maps";
 @import "../../node_modules/bootstrap/scss/mixins";
 @import "../../node_modules/bootstrap/scss/utilities";
+
+@import "./custom-mixins";
 
 // Layout & components
 @import "../../node_modules/bootstrap/scss/root";


### PR DESCRIPTION
In this commit, I created 3 files:

1.  ```_initial-variables.scss``` replaces the color scheme established by bootstrap with my own dummy color palette.
2. ```_custom-variables.scss``` allows me to use each color in my color scheme with different shades to show hover states similar to bootstrap.
3.  ```_custom-mixins.scss``` allows me to add container queries for better layout shifting.

In addition, I also enabled _css-grid_