### PR TITLE
Added hook to not duplicate 'context' functionality

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,15 +1,12 @@
-import { useContext } from 'react';
-import { ThemeContext } from '../context/ThemeContext';
+import { useTheme } from "../hooks/useTheme";
 
 const Header: React.FC = () => {
-  const context = useContext(ThemeContext);
-  if (!context) throw new Error('ThemeContext not found');
-  const { theme, toggleTheme } = context;
+  const { theme, toggleTheme } = useTheme()
+
   return (
     <header>
-      Header
       <button onClick={toggleTheme}>
-      Switch to {theme === 'light' ? 'dark' : 'light'} mode
+      {theme === 'light' ? '🌙' : '🌤️'}
       </button>
     </header>
   )

--- a/client/src/hooks/useTheme.tsx
+++ b/client/src/hooks/useTheme.tsx
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { ThemeContext } from "../context/ThemeContext";
+
+export const useTheme = () => {
+    const context = useContext(ThemeContext)
+    if (!context) {
+        throw new Error('useTheme must be used within a ThemeProvider')
+    }
+    return context;
+}


### PR DESCRIPTION
Because I plan on having a theme toggle in the header, mobile menu, and footer, I put the following code into a hook to not duplicate functionality:

```
  const context = useContext(ThemeContext);
  if (!context) throw new Error('ThemeContext not found');
  const { theme, toggleTheme } = context;
```